### PR TITLE
feature/getAuditlog

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { VistoriasModule } from './vistorias/vistorias.module';
 import { ProspeccoesModule } from './prospeccoes/prospeccoes.module';
 import { SalvaguardaModule } from './salvaguarda/salvaguarda.module';
 import { DevtoolsModule } from '@nestjs/devtools-integration';
+import { AuditoriasModule } from './auditorias/auditorias.module';
 
 @Global()
 @Module({
@@ -34,6 +35,7 @@ import { DevtoolsModule } from '@nestjs/devtools-integration';
     IntegracoesModule,
     VistoriasModule,
     ProspeccoesModule,
+    AuditoriasModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/auditorias/auditorias.controller.ts
+++ b/src/auditorias/auditorias.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { AuditoriasService } from './auditorias.service';
+import { Permissoes } from 'src/auth/decorators/permissoes.decorator';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Order, PaginationQueryDto } from 'src/common/dtos/pagination.dto';
+
+export enum OrderByFields {
+  criadoEm = 'criadoEm',
+}
+
+@ApiTags('auditorias')
+@Permissoes('ADM', 'SUP', 'DEV')
+@ApiBearerAuth()
+@Controller('auditorias')
+export class AuditoriasController {
+  constructor(private readonly auditoriasService: AuditoriasService) {}
+
+  @Get('buscar-alteracoes')
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    type: Number,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    type: Number,
+  })
+  @ApiQuery({
+    name: 'orderBy',
+    required: false,
+    enum: OrderByFields,
+  })
+  @ApiQuery({
+    name: 'order',
+    required: false,
+    enum: Order,
+  })
+  findAll(@Query() paginationQuery: PaginationQueryDto) {
+    return this.auditoriasService.findAll(paginationQuery);
+  }
+
+  @Get('buscar-alteracao/:id')
+  findOne(@Param('id') id: string) {
+    return this.auditoriasService.findOne(+id);
+  }
+}

--- a/src/auditorias/auditorias.module.ts
+++ b/src/auditorias/auditorias.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AuditoriasService } from './auditorias.service';
+import { AuditoriasController } from './auditorias.controller';
+
+@Module({
+  controllers: [AuditoriasController],
+  providers: [AuditoriasService],
+})
+export class AuditoriasModule {}

--- a/src/auditorias/auditorias.service.ts
+++ b/src/auditorias/auditorias.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PaginationQueryDto } from 'src/common/dtos/pagination.dto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class AuditoriasService {
+  constructor(private prisma: PrismaService) {}
+
+  async findAll(paginationQuery: PaginationQueryDto) {
+    const {
+      limit = 10,
+      offset = 0,
+      order = 'asc',
+      orderBy = 'criadoEm',
+    } = paginationQuery;
+
+    // OrderBy dinâmico
+    const orderByFields = orderBy ? { [orderBy]: order } : undefined;
+
+    return this.prisma.auditoria.findMany({
+      take: +limit,
+      skip: +offset,
+      orderBy: orderByFields,
+    });
+  }
+
+  findOne(id: number) {
+    return this.prisma.auditoria.findUnique({
+      where: { id },
+    });
+  }
+}


### PR DESCRIPTION
## getAuditlog

### 1. Finalidade da funcionalidade de getAuditlog

#### O que é? 
É um par de rotas de leitura (verbo: GET), cujo as funções findAll e findOne (Figura 1) são implementadas.

#### Por que?
Esta funcionalidade de leitura de usuários que executaram determinadas ações. Essa funcionalidade pode ser acrescentada ao front-end como `O usuário ${usuario} ${enum.verbo} na rota {$rota}, de ${id}, em ${criadoEm}.`, onde: `enum.verbo = ['criou', 'consultou', 'atualizou', 'excluiu']`. Alguns potenciais exemplos são:

- O usuário Fulano criou um registro de vistoria, cujo o identificador é #223094, em 10/07/2024 às 14:00h.
- O usuário Ciclano excluiu um registro de imóvel, cujo o identificador é #223094 há 5 dias. Para consultar detalhes, clique aqui.

... ao clicar ali :point_up::

```
-------
O usuário Ciclano excluiu um registro de imóvel #223094 em 10/07/2024 às 14:00h. Os detalhes são:

Imóvel: 223094
SQL: 123.456.7890-1
SQL Pai: 123.456.789
Endereço: Rua dos bobos, número 0
Bairro: XYZ
... [registros presentes no DTO de imóveis]
-------
```

#### Quem? Onde? Quando?
A funcionalidade pode ser limitada a determinados usuários pelo decorador de `@Permissoes` e ocorre por meio de chamada do front-end em `/auditorias/buscar-alteracoes` (Figura 2) e `/auditorias/buscar-alteracao/:id` (Figura 3). A funcionalidade ocorre majoritariamente no módulo cujo o caminho é `src/auditorias/*`.

Figura 1: Funções de leitura de registros de auditoria dos usuários.
<img width="730" alt="Captura de Tela 2024-09-12 às 16 22 42" src="https://github.com/user-attachments/assets/3f001229-f2a1-4d68-b8c5-cba5852ddc23">
Fonte: @crscnc 

Figura 2: Função findAll:
<img width="722" alt="Captura de Tela 2024-09-12 às 16 23 04" src="https://github.com/user-attachments/assets/322a4b6c-5bd5-49b7-b18e-402ea3de8c07">
Fonte: @crscnc 

Figura 3: Função findOne:
<img width="723" alt="Captura de Tela 2024-09-12 às 16 23 19" src="https://github.com/user-attachments/assets/5015f8af-14c0-4ebd-84cf-9e7a6179122a">
Fonte: @crscnc 
