### PR TITLE
Busca por texto completa e busca por identificadores

### DIFF
--- a/prisma/schema/dominios-iniciais.prisma
+++ b/prisma/schema/dominios-iniciais.prisma
@@ -9,7 +9,7 @@ model Processo {
     id                  Int                  @id @default(autoincrement())
     // imovelId            Int?
     // vistoriaId          Int?
-    autuacaoSei         Int?                 @unique ///Nr processo SEI. Único, mas nem sempre preenchido.
+    autuacaoSei         String?              @unique ///Nr processo SEI. Único, mas nem sempre preenchido.
     autuacaoData        DateTime?
     imovelContiguidade  Boolean              @default(false)
     estado              String?              @db.VarChar(20)
@@ -32,8 +32,8 @@ model Processo {
 
 model Vistoria {
     id                            Int            @id @default(autoincrement())
-    processoId                    Int? ///autuacaoSei. Chave humana.
-    imovelId                      Int? ///SQL. Chave humana.
+    processoId                    String? ///autuacaoSei. Chave humana.
+    imovelId                      String? ///SQL. Chave humana.
     tipoVistoria                  TipoVistoria?
     tipoTipologia                 TipoTipologia?
     tipoUso                       TipoUso?
@@ -74,8 +74,8 @@ model Imovel {
     id                                  Int                         @id @default(autoincrement())
     // matriculaId                         Int                                    @unique
     // vistoriaId                          Int                                    @unique
-    seiId                               Int? ///autuacaoSei. Chave humana.
-    sqlId                               Int? ///SQL. Chave humana.
+    seiId                               String? ///autuacaoSei. Chave humana. Usado para relacionar com o processo.
+    sqlId                               String? ///SQL. Chave humana.
     sqlSetor                            Int?
     sqlQuadra                           Int?
     sqlLote                             Int?

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -10,7 +10,7 @@
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["prismaSchemaFolder", "postgresqlExtensions"]
+  previewFeatures = ["prismaSchemaFolder", "postgresqlExtensions", "fullTextSearch"]
 }
 
 datasource db {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { ProspeccoesModule } from './prospeccoes/prospeccoes.module';
 import { SalvaguardaModule } from './salvaguarda/salvaguarda.module';
 import { DevtoolsModule } from '@nestjs/devtools-integration';
 import { AuditoriasModule } from './auditorias/auditorias.module';
+import { BuscasModule } from './buscas/buscas.module';
 
 @Global()
 @Module({
@@ -36,6 +37,7 @@ import { AuditoriasModule } from './auditorias/auditorias.module';
     VistoriasModule,
     ProspeccoesModule,
     AuditoriasModule,
+    BuscasModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/buscas/buscas.controller.ts
+++ b/src/buscas/buscas.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { SearchQueryDto } from './dto/search-query.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Permissoes } from 'src/auth/decorators/permissoes.decorator';
+import { BuscasService } from './buscas.service';
+
+@ApiTags('buscas')
+// @UseInterceptors(AuditingInterceptor)
+// @AuditTable('vistorias')
+@Permissoes('ADM', 'SUP', 'DEV')
+@ApiBearerAuth()
+@Controller('buscas')
+export class BuscasController {
+  constructor(private readonly buscasService: BuscasService) {}
+
+  @Get('buscar-por-id')
+  async search(@Query() searchQueryDto: SearchQueryDto) {
+    const { model, query } = searchQueryDto;
+    const strategy = this.buscasService.getStrategy(model);
+    return strategy.search(query);
+  }
+}

--- a/src/buscas/buscas.controller.ts
+++ b/src/buscas/buscas.controller.ts
@@ -19,4 +19,11 @@ export class BuscasController {
     const strategy = this.buscasService.getStrategy(model);
     return strategy.search(query);
   }
+
+  @Get('buscar-por-texto')
+  async fulltextsearch(@Query() searchQueryDto: SearchQueryDto) {
+    const { model, query } = searchQueryDto;
+    const strategy = this.buscasService.getFullTextSearchStrategy(model);
+    return strategy.search(query);
+  }
 }

--- a/src/buscas/buscas.module.ts
+++ b/src/buscas/buscas.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { BuscasService } from './buscas.service';
+import { BuscasController } from './buscas.controller';
+import { VistoriaBuscaStrategy } from './strategies/vistoria-busca.strategy';
+import { ProcessoBuscaStrategy } from './strategies/processo-busca.strategy';
+import { ImovelBuscaStrategy } from './strategies/imovel-busca.strategy';
+
+@Module({
+  imports: [],
+  controllers: [BuscasController],
+  providers: [
+    BuscasService,
+    VistoriaBuscaStrategy,
+    ProcessoBuscaStrategy,
+    ImovelBuscaStrategy,
+  ],
+})
+export class BuscasModule {}

--- a/src/buscas/buscas.module.ts
+++ b/src/buscas/buscas.module.ts
@@ -4,6 +4,9 @@ import { BuscasController } from './buscas.controller';
 import { VistoriaBuscaStrategy } from './strategies/vistoria-busca.strategy';
 import { ProcessoBuscaStrategy } from './strategies/processo-busca.strategy';
 import { ImovelBuscaStrategy } from './strategies/imovel-busca.strategy';
+import { ImovelBuscaTextoStrategy } from './strategies/imovel-busca-texto.strategy';
+import { ProcessoBuscaTextoStrategy } from './strategies/processo-busca-texto.strategy';
+import { VistoriaBuscaTextoStrategy } from './strategies/vistoria-busca-texto.strategy';
 
 @Module({
   imports: [],
@@ -11,8 +14,11 @@ import { ImovelBuscaStrategy } from './strategies/imovel-busca.strategy';
   providers: [
     BuscasService,
     VistoriaBuscaStrategy,
+    VistoriaBuscaTextoStrategy,
     ProcessoBuscaStrategy,
+    ProcessoBuscaTextoStrategy,
     ImovelBuscaStrategy,
+    ImovelBuscaTextoStrategy,
   ],
 })
 export class BuscasModule {}

--- a/src/buscas/buscas.service.ts
+++ b/src/buscas/buscas.service.ts
@@ -3,6 +3,9 @@ import { Injectable } from '@nestjs/common';
 import { VistoriaBuscaStrategy } from './strategies/vistoria-busca.strategy';
 import { ImovelBuscaStrategy } from './strategies/imovel-busca.strategy';
 import { ProcessoBuscaStrategy } from './strategies/processo-busca.strategy';
+import { VistoriaBuscaTextoStrategy } from './strategies/vistoria-busca-texto.strategy';
+import { ImovelBuscaTextoStrategy } from './strategies/imovel-busca-texto.strategy';
+import { ProcessoBuscaTextoStrategy } from './strategies/processo-busca-texto.strategy';
 
 export interface BuscasStrategy {
   search(query: string | number): Promise<any>;
@@ -20,6 +23,9 @@ export class BuscasService {
     private readonly vistoriaBuscaStrategy: VistoriaBuscaStrategy,
     private readonly imovelBuscaStrategy: ImovelBuscaStrategy,
     private readonly processoBuscaStrategy: ProcessoBuscaStrategy,
+    private readonly vistoriaBuscaTextoStrategy: VistoriaBuscaTextoStrategy,
+    private readonly imovelBuscaTextoStrategy: ImovelBuscaTextoStrategy,
+    private readonly processoBuscaTextoStrategy: ProcessoBuscaTextoStrategy,
   ) {}
 
   getStrategy(model: SearchType): BuscasStrategy {
@@ -30,6 +36,19 @@ export class BuscasService {
         return this.imovelBuscaStrategy;
       case SearchType.PROCESSO:
         return this.processoBuscaStrategy;
+      default:
+        throw new Error('No matching strategy found');
+    }
+  }
+
+  getFullTextSearchStrategy(model: SearchType): BuscasStrategy {
+    switch (model) {
+      case SearchType.VISTORIA:
+        return this.vistoriaBuscaTextoStrategy;
+      case SearchType.IMOVEL:
+        return this.imovelBuscaTextoStrategy;
+      case SearchType.PROCESSO:
+        return this.processoBuscaTextoStrategy;
       default:
         throw new Error('No matching strategy found');
     }

--- a/src/buscas/buscas.service.ts
+++ b/src/buscas/buscas.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+
+import { VistoriaBuscaStrategy } from './strategies/vistoria-busca.strategy';
+import { ImovelBuscaStrategy } from './strategies/imovel-busca.strategy';
+import { ProcessoBuscaStrategy } from './strategies/processo-busca.strategy';
+
+export interface BuscasStrategy {
+  search(query: string | number): Promise<any>;
+}
+
+export enum SearchType {
+  PROCESSO = 'processo',
+  IMOVEL = 'imovel',
+  VISTORIA = 'vistoria',
+}
+
+@Injectable()
+export class BuscasService {
+  constructor(
+    private readonly vistoriaBuscaStrategy: VistoriaBuscaStrategy,
+    private readonly imovelBuscaStrategy: ImovelBuscaStrategy,
+    private readonly processoBuscaStrategy: ProcessoBuscaStrategy,
+  ) {}
+
+  getStrategy(model: SearchType): BuscasStrategy {
+    switch (model) {
+      case SearchType.VISTORIA:
+        return this.vistoriaBuscaStrategy;
+      case SearchType.IMOVEL:
+        return this.imovelBuscaStrategy;
+      case SearchType.PROCESSO:
+        return this.processoBuscaStrategy;
+      default:
+        throw new Error('No matching strategy found');
+    }
+  }
+}

--- a/src/buscas/dto/search-query.dto.ts
+++ b/src/buscas/dto/search-query.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+
+export enum SearchType {
+  PROCESSO = 'processo',
+  IMOVEL = 'imovel',
+  VISTORIA = 'vistoria',
+}
+
+export class SearchQueryDto {
+  @ApiProperty({
+    description: 'Selecione o modelo',
+    required: false,
+    enum: SearchType,
+    default: SearchType.IMOVEL,
+  })
+  @IsEnum(SearchType)
+  model?: SearchType = SearchType.IMOVEL;
+
+  @ApiProperty({
+    description: 'Campos aceitos: SQL, Autuação SEI, ID',
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  query: string;
+}

--- a/src/buscas/dto/search-query.dto.ts
+++ b/src/buscas/dto/search-query.dto.ts
@@ -18,7 +18,7 @@ export class SearchQueryDto {
   model?: SearchType = SearchType.IMOVEL;
 
   @ApiProperty({
-    description: 'Campos aceitos: SQL, Autuação SEI, ID',
+    description: `Campos aceitos: \n SQL, Autuação SEI, ID`,
     required: true,
   })
   @IsNotEmpty()

--- a/src/buscas/strategies/imovel-busca-texto.strategy.ts
+++ b/src/buscas/strategies/imovel-busca-texto.strategy.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ImovelBuscaTextoStrategy {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async search(query: string) {
+    return await this.prisma.imovel.findMany({
+      where: {
+        deletado: false,
+
+        sqlId: {
+          search: query,
+        },
+
+        seiId: {
+          search: query,
+        },
+
+        enderecoLogradouro: {
+          search: query,
+        },
+
+        enderecoReferencia: {
+          search: query,
+        },
+
+        registroNotasReferencia: {
+          search: query,
+        },
+        usuarioId: {
+          search: query,
+        },
+      },
+    });
+  }
+}

--- a/src/buscas/strategies/imovel-busca.strategy.ts
+++ b/src/buscas/strategies/imovel-busca.strategy.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ImovelBuscaStrategy {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async search(query: string) {
+    const queryInt = parseInt(query, 10);
+
+    return this.prisma.imovel.findMany({
+      where: {
+        OR: [
+          {
+            sqlId: {
+              contains: query,
+              mode: 'insensitive',
+            },
+          },
+          {
+            ...(!isNaN(queryInt) && { id: queryInt }),
+          },
+        ],
+      },
+    });
+  }
+}

--- a/src/buscas/strategies/processo-busca-texto.strategy.ts
+++ b/src/buscas/strategies/processo-busca-texto.strategy.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ProcessoBuscaTextoStrategy {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async search(query: string) {
+    return await this.prisma.processo.findMany({
+      where: {
+        arquivado: false,
+        autuacaoSei: {
+          search: query,
+        },
+        estado: {
+          search: query,
+        },
+        usuarioId: {
+          search: query,
+        },
+      },
+    });
+  }
+}

--- a/src/buscas/strategies/processo-busca.strategy.ts
+++ b/src/buscas/strategies/processo-busca.strategy.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class ProcessoBuscaStrategy {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async search(query: string) {
+    const queryInt = parseInt(query, 10);
+
+    return this.prisma.processo.findMany({
+      where: {
+        OR: [
+          {
+            autuacaoSei: {
+              contains: query,
+              mode: 'insensitive',
+            },
+          },
+          {
+            ...(!isNaN(queryInt) && { id: queryInt }),
+          },
+        ],
+      },
+    });
+  }
+}

--- a/src/buscas/strategies/vistoria-busca-texto.strategy.ts
+++ b/src/buscas/strategies/vistoria-busca-texto.strategy.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class VistoriaBuscaTextoStrategy {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async search(query: string) {
+    return await this.prisma.vistoria.findMany({
+      where: {
+        deletado: false,
+        processoId: {
+          search: query,
+        },
+        imovelId: {
+          search: query,
+        },
+        descricao: {
+          search: query,
+        },
+        usuarioId: {
+          search: query,
+        },
+      },
+    });
+  }
+}

--- a/src/buscas/strategies/vistoria-busca.strategy.ts
+++ b/src/buscas/strategies/vistoria-busca.strategy.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class VistoriaBuscaStrategy {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async search(query: string) {
+    const queryInt = parseInt(query, 10);
+
+    return this.prisma.vistoria.findMany({
+      where: {
+        OR: [
+          {
+            processoId: {
+              contains: query,
+              mode: 'insensitive',
+            },
+          },
+          {
+            imovelId: {
+              contains: query,
+              mode: 'insensitive',
+            },
+          },
+          {
+            ...(!isNaN(queryInt) && { id: queryInt }),
+          },
+        ],
+      },
+    });
+  }
+}

--- a/src/cadastros/cadastros.controller.ts
+++ b/src/cadastros/cadastros.controller.ts
@@ -3,7 +3,6 @@ import {
   Get,
   Post,
   Body,
-  Patch,
   Param,
   Delete,
   Query,
@@ -12,14 +11,9 @@ import {
 } from '@nestjs/common';
 import { CadastrosService } from './cadastros.service';
 import { CreateCadastroDto } from './dto/create-cadastro.dto';
-import { UpdateCadastroDto } from './dto/update-cadastro.dto';
-import {
-  Order,
-  OrderByFields,
-  PaginationQueryDto,
-} from './dto/pagination-cadastro.dto';
+import { PaginationQueryDto } from './dto/pagination-cadastro.dto';
 import { Permissoes } from 'src/auth/decorators/permissoes.decorator';
-import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { UsuarioAtual } from 'src/auth/decorators/usuario-atual.decorator';
 import { Usuario } from '@prisma/client';
 import { AuditInterceptor } from 'src/common/interceptors/audit.interceptor';
@@ -41,26 +35,6 @@ export class CadastrosController {
   }
 
   @Get('buscar-cadastros')
-  @ApiQuery({
-    name: 'limit',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'offset',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'orderBy',
-    required: false,
-    enum: OrderByFields,
-  })
-  @ApiQuery({
-    name: 'order',
-    required: false,
-    enum: Order,
-  })
   findAll(@Query() paginationQuery: PaginationQueryDto) {
     return this.cadastrosService.findAll(paginationQuery);
   }
@@ -68,15 +42,6 @@ export class CadastrosController {
   @Get('buscar-cadastro/:id')
   findOne(@Param('id') id: string) {
     return this.cadastrosService.findOne(+id);
-  }
-
-  @Patch('atualizar-cadastro/:id')
-  async update(
-    @Param('id') id: string,
-    @Body() updateCadastroDto: UpdateCadastroDto,
-    @UsuarioAtual() usuario: Usuario,
-  ) {
-    return this.cadastrosService.update(+id, updateCadastroDto, usuario.login);
   }
 
   @Delete('excluir-cadastro/:id')

--- a/src/cadastros/cadastros.module.ts
+++ b/src/cadastros/cadastros.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CadastrosService } from './cadastros.service';
 import { CadastrosController } from './cadastros.controller';
+import { ProcessosController } from './processos.controller';
+import { ProcessosService } from './processos.service';
 
 @Module({
-  controllers: [CadastrosController],
-  providers: [CadastrosService],
+  controllers: [CadastrosController, ProcessosController],
+  providers: [CadastrosService, ProcessosService],
 })
 export class CadastrosModule {}

--- a/src/cadastros/dto/create-imovel.dto.ts
+++ b/src/cadastros/dto/create-imovel.dto.ts
@@ -9,8 +9,8 @@ export class CreateImovelDto {
   // @ApiProperty()
   // vistoriaId: number;
 
-  @ApiProperty()
-  processoId: number;
+  // @ApiProperty()
+  // processoId: number;
 
   @ApiProperty()
   sqlSetor?: number;
@@ -126,7 +126,7 @@ export class CreateImovelDto {
   constructor(partial: Partial<CreateImovelDto> = {}) {
     // this.matriculaId = partial.matriculaId ?? 0; // Default value or value from partial
     // this.vistoriaId = partial.vistoriaId ?? 0;
-    this.processoId = partial.processoId ?? 0;
+    // this.processoId = partial.processoId ?? 0;
     this.sqlSetor = partial.sqlSetor ?? null;
     this.sqlQuadra = partial.sqlQuadra ?? null;
     this.sqlLote = partial.sqlLote ?? null;

--- a/src/cadastros/dto/create-processo.dto.ts
+++ b/src/cadastros/dto/create-processo.dto.ts
@@ -10,7 +10,7 @@ export class CreateProcessoDto {
   // vistoriaId?: number;
 
   @ApiProperty()
-  autuacaoSei?: number;
+  autuacaoSei?: string;
 
   @ApiProperty()
   autuacaoData?: Date;

--- a/src/cadastros/dto/update-cadastro.dto.ts
+++ b/src/cadastros/dto/update-cadastro.dto.ts
@@ -1,4 +1,0 @@
-import { CreateCadastroDto } from './create-cadastro.dto';
-import { PartialType } from '@nestjs/swagger';
-
-export class UpdateCadastroDto extends PartialType(CreateCadastroDto) {}

--- a/src/cadastros/dto/update-processo.dto.ts
+++ b/src/cadastros/dto/update-processo.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProcessoDto } from './create-processo.dto';
+
+export class UpdateProcessoDto extends PartialType(CreateProcessoDto) {}

--- a/src/cadastros/processos.controller.ts
+++ b/src/cadastros/processos.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Controller,
+  Post,
+  Body,
+  UseInterceptors,
+  Get,
+  Query,
+  Param,
+  Patch,
+  Delete,
+  NotFoundException,
+} from '@nestjs/common';
+import { Permissoes } from 'src/auth/decorators/permissoes.decorator';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { UsuarioAtual } from 'src/auth/decorators/usuario-atual.decorator';
+import { Usuario } from '@prisma/client';
+import { AuditInterceptor } from 'src/common/interceptors/audit.interceptor';
+import { ProcessosService } from './processos.service';
+import { CreateProcessoDto } from './dto/create-processo.dto';
+import { PaginationQueryDto } from 'src/common/dtos/pagination.dto';
+import { UpdateProcessoDto } from './dto/update-processo.dto';
+
+@ApiTags('cadastros')
+@Permissoes('ADM', 'SUP', 'DEV')
+@ApiBearerAuth()
+@UseInterceptors(AuditInterceptor)
+@Controller('processos')
+export class ProcessosController {
+  constructor(private readonly processosService: ProcessosService) {}
+
+  @Post('criar-processo')
+  create(
+    @UsuarioAtual() usuario: Usuario,
+    @Body() createProcessoDto: CreateProcessoDto,
+  ) {
+    return this.processosService.create(usuario.id, createProcessoDto);
+  }
+
+  @Get('buscar-processos')
+  findAll(@Query() paginationQuery: PaginationQueryDto) {
+    return this.processosService.findAll(paginationQuery);
+  }
+
+  @Get('buscar-processo/:id')
+  findOne(@Param('id') id: string) {
+    return this.processosService.findOne(+id);
+  }
+
+  @Patch('atualizar-processo/:id')
+  update(
+    @Param('id') id: string,
+    @UsuarioAtual() usuario: Usuario,
+    @Body() updateProcessoDto: UpdateProcessoDto,
+  ) {
+    return this.processosService.update(+id, usuario.id, updateProcessoDto);
+  }
+
+  @Delete('excluir-processo/:id')
+  async remove(@Param('id') id: string) {
+    try {
+      const result = await this.processosService.remove(+id);
+      return result;
+    } catch (error) {
+      if (error.code === 'P2025') {
+        throw new NotFoundException(`Registro não encontrado: ${id} ${error}`);
+      }
+      throw error;
+    }
+  }
+}

--- a/src/common/dtos/pagination.dto.ts
+++ b/src/common/dtos/pagination.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsInt, Min, IsEnum, IsNotEmpty } from 'class-validator';
+import { IsOptional, IsInt, Min, IsEnum } from 'class-validator';
 
 export enum Order {
   ASC = 'asc',
   DESC = 'desc',
 }
 
-export enum OrderByFields {
+export enum OrderBy {
   CRIADO_EM = 'criadoEm',
   ATUALIZADO_EM = 'atualizadoEm',
 }
@@ -30,12 +30,11 @@ export class PaginationQueryDto {
   @ApiProperty({
     description: 'Campo para ordenação.',
     required: false,
-    enum: OrderByFields,
-    default: OrderByFields.ATUALIZADO_EM,
+    enum: OrderBy,
+    default: OrderBy.ATUALIZADO_EM,
   })
-  @IsOptional()
-  @IsEnum(OrderByFields)
-  orderBy?: OrderByFields = OrderByFields.ATUALIZADO_EM;
+  @IsEnum(OrderBy)
+  orderBy?: OrderBy = OrderBy.ATUALIZADO_EM;
 
   @ApiProperty({
     description: 'Ordem da ordenação.',
@@ -43,7 +42,6 @@ export class PaginationQueryDto {
     enum: Order,
     default: Order.ASC,
   })
-  @IsNotEmpty()
   @IsEnum(Order)
   order?: Order = Order.ASC;
 }

--- a/src/common/interceptors/audit.interceptor.ts
+++ b/src/common/interceptors/audit.interceptor.ts
@@ -55,10 +55,12 @@ export class AuditInterceptor implements NestInterceptor {
 
   private getRouteNameFromRoute(route: string): string {
     const cadastroPattern = /\/cadastros?/i;
+    const processoPattern = /\/processos?/i;
     const vistoriaPattern = /\/vistorias?/i;
     const prospeccaoPattern = /\/prospeccoes?/i;
 
     if (cadastroPattern.test(route)) return 'cadastro';
+    if (processoPattern.test(route)) return 'processo';
     if (vistoriaPattern.test(route)) return 'vistoria';
     if (prospeccaoPattern.test(route)) return 'prospeccao';
 

--- a/src/prospeccoes/dto/create-prospeccao.dto.ts
+++ b/src/prospeccoes/dto/create-prospeccao.dto.ts
@@ -18,10 +18,10 @@ export class CreateProspeccaoDto {
   // vistoriaId: number;
 
   @ApiProperty()
-  seiId?: number;
+  seiId?: string;
 
   @ApiProperty()
-  sqlId?: number;
+  sqlId?: string;
 
   @ApiProperty()
   sqlSetor?: number;

--- a/src/prospeccoes/prospeccoes.controller.ts
+++ b/src/prospeccoes/prospeccoes.controller.ts
@@ -14,12 +14,8 @@ import { ProspeccoesService } from './prospeccoes.service';
 import { CreateProspeccaoDto } from './dto/create-prospeccao.dto';
 import { CreateManyProspeccaoDto } from './dto/createmany-prospeccao.dto';
 import { UpdateProspeccaoDto } from './dto/update-prospeccao.dto';
-import {
-  Order,
-  OrderByFields,
-  PaginationQueryDto,
-} from 'src/common/dtos/pagination.dto';
-import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger';
+import { PaginationQueryDto } from 'src/common/dtos/pagination.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Permissoes } from 'src/auth/decorators/permissoes.decorator';
 import { UsuarioAtual } from 'src/auth/decorators/usuario-atual.decorator';
 import { Usuario } from '@prisma/client';
@@ -53,26 +49,6 @@ export class ProspeccoesController {
   }
 
   @Get('buscar-imoveis')
-  @ApiQuery({
-    name: 'limit',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'offset',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'orderBy',
-    required: false,
-    enum: OrderByFields,
-  })
-  @ApiQuery({
-    name: 'order',
-    required: false,
-    enum: Order,
-  })
   findAll(@Query() paginationQuery: PaginationQueryDto) {
     return this.prospeccoesService.findAll(paginationQuery);
   }

--- a/src/vistorias/dto/create-vistoria.dto.ts
+++ b/src/vistorias/dto/create-vistoria.dto.ts
@@ -17,13 +17,13 @@ export class CreateVistoriaDto {
 
   @ApiProperty()
   @IsOptional()
-  @IsInt()
-  processoId?: number;
+  @IsString()
+  processoId?: string;
 
   @ApiProperty()
   @IsOptional()
-  @IsInt()
-  imovelId?: number;
+  @IsString()
+  imovelId?: string;
 
   @ApiProperty()
   @IsOptional()

--- a/src/vistorias/dto/update-vistoria.dto.ts
+++ b/src/vistorias/dto/update-vistoria.dto.ts
@@ -17,13 +17,13 @@ export class UpdateVistoriaDto {
 
   @ApiProperty()
   @IsOptional()
-  @IsInt()
-  processoId?: number;
+  @IsString()
+  processoId?: string;
 
   @ApiProperty()
   @IsOptional()
-  @IsInt()
-  imovelId?: number;
+  @IsString()
+  imovelId?: string;
 
   @ApiProperty()
   @IsOptional()

--- a/src/vistorias/vistorias.controller.ts
+++ b/src/vistorias/vistorias.controller.ts
@@ -13,20 +13,14 @@ import {
 import { VistoriasService } from './vistorias.service';
 import { CreateVistoriaDto } from './dto/create-vistoria.dto';
 import { UpdateVistoriaDto } from './dto/update-vistoria.dto';
-import {
-  Order,
-  OrderByFields,
-  PaginationQueryDto,
-} from 'src/common/dtos/pagination.dto';
+import { PaginationQueryDto } from 'src/common/dtos/pagination.dto';
 import { UsuarioAtual } from 'src/auth/decorators/usuario-atual.decorator';
 import { Usuario } from '@prisma/client';
-import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Permissoes } from 'src/auth/decorators/permissoes.decorator';
 import { AuditInterceptor } from 'src/common/interceptors/audit.interceptor';
 
 @ApiTags('vistorias')
-// @UseInterceptors(AuditingInterceptor)
-// @AuditTable('vistorias')
 @Permissoes('ADM', 'SUP', 'DEV')
 @ApiBearerAuth()
 @UseInterceptors(AuditInterceptor)
@@ -43,26 +37,6 @@ export class VistoriasController {
   }
 
   @Get('buscar-vistorias')
-  @ApiQuery({
-    name: 'limit',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'offset',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'orderBy',
-    required: false,
-    enum: OrderByFields,
-  })
-  @ApiQuery({
-    name: 'order',
-    required: false,
-    enum: Order,
-  })
   findAll(@Query() paginationQuery: PaginationQueryDto) {
     return this.vistoriasService.findAll(paginationQuery);
   }


### PR DESCRIPTION
## fullTextSeach e search

### 1. Finalidade das funcionalidades de busca completa por texto e busca por identificadores

#### 1.1 O que é?

São duas rotas distintas, e para ambas, seleciona-se o modelo a buscar (ex: `processo`, `imovel`). A rota `/busca-por-id` consulta (verbo: GET) identificadores do banco de dados (`id`) e identificadores amigáveis (ex: `idSei`).

#### 1.2 Por que?

Esta funcionalidade foi solicitada pela área de negócio, consta em leiautes propositivos e existe no sistema anterior. Complementarmente, é uma boa prática haver funcionalidades de busca em sistemas informáticos.

#### 1.3 Quem? Onde? Quando?

A funcionalidade ocorre por meio de chamada do front-end em `/buscas/busca-por-id` e `buscas/busca-por-texto` (Figura 1). A funcionalidade ocorre majoritariamente no módulo cujo o caminho é `src/buscas/*`. As buscas for segmentadas por domínios em `src/buscas/strategies`.

#### 1.4 Como?

Foram desenvolvidas duas rotas. A busca por identificadores é uma funcionalidade estável do Prisma ORM. A busca por texto é uma funcionalidade em testes (estado `preview`)(Referências 1 e 2), portanto alguns campos de busca são sobrepostos na segunda rota, uma vez que há o risco da mesma ser descontinuada. No cenário tradicional, a funcionalidade estável permanece e a `preview` é removida. No cenário de vanguarda, a funcionalidade `preview` terá seus problemas conhecidos resolvidos (Referências 3 e 4) e poderá ser incorporada definitivamente ao ORM, e posteriormente,  substituir a rota de busca por identificador.

Para `buscar-por-id`, os identificadores são:

##### 1.4.1 Entidade imóveis, busca por identificadores:
- `id` Id do banco de dados;
- `sqlId` Id amigável do Setor-Quadra-Lote.

##### 1.4.2 Entidade processos, busca por identificadores:
- `id` Id do banco de dados;
- `autuacaoSei` Id amigável do número de processo SEI.

##### 1.4.3 Entidade vistorias, busca por identificadores:
- `id` Id do banco de dados;
- `processoId` Id amigável do número de processo SEI;
- `imovelId` Id amigável do Setor-Quadra-Lote.

Para `buscar-por-texto`, os campos são:

##### 1.4.4 Entidade imóveis, busca por texto:
  - `sqlId` Id amigável do Setor-Quadra-Lote;
  - `seiId` Id amigável do número de processo SEI;
  - `enderecoLogradouro` Endereço, formato linha de texto;
  - `enderecoReferencia` Campo de texto auxiliar ao logradouro;
  - `registroNotasReferencia` Campo de texto para anotações gerais;
  - `usuarioId` Nome do usuário.

##### 1.4.5 Entidade processos, busca por texto:
- `autuacaoSei` Id amigável do número de processo SEI.
- `estado` Campo de texto para anotações gerais;
- `usuarioId` Nome do usuário.

##### 1.4.6 Entidade vistorias, busca por texto:
- `processoId` Id amigável do número de processo SEI.
- `imovelId` Id amigável do Setor-Quadra-Lote;
- `descricao` Campo de texto para anotações gerais;
- `usuarioId` Nome do usuário.

Figura 1: Rotas de busca.
<img width="726" alt="image" src="https://github.com/user-attachments/assets/d73d18c8-d25b-41bb-b5cc-104adc35b33b">
Fonte: @crscnc 

### 2. Demonstração de funcionalidade

#### 2.1 Buscar imóvel por identificador (Figura 2). Os imóveis podem ser buscados por `id`, `seiId` e `sqlId`.

Figura 2: Imóvel encontrado por meio do identificador `id: 2`
<img width="723" alt="image" src="https://github.com/user-attachments/assets/fa17f12d-11ab-4354-bfa8-f126b1311685">
Fonte: @crscnc 


#### 2.2 Buscar processo por identificador (Figura 3). Os processos podem ser buscados por `id` e `autuacaoSei`.

Figura 3: Busca de um processo por meio do número de processo SEI `autuacaoSei: 12345678`
<img width="727" alt="image" src="https://github.com/user-attachments/assets/0b45d084-f027-402d-a28b-bda0ed845069">
Fonte: @crscnc 


#### 2.3 Buscar vistoria por identificador (Figura 4). As vistorias podem ser buscadas por `id`, `processoId` e `imovelId`.

Figura 4: Buscar uma vistoria por meio de seu SQL `imovelId: 123456`
<img width="726" alt="image" src="https://github.com/user-attachments/assets/6ded9e54-c6b1-417c-8cd6-d23332ca1e6d">
Fonte: @crscnc 


#### 2.4 Buscar imóvel por texto (Figura 5).  Os imóveis podem ser buscados por `sqlId`, `seiId`, `enderecoLogradouro`, `enderecoReferencia`, `registroNotasReferencia` e `usuarioId`.

Figura 5: Buscar por imóveis em múltiplos campos. A busca pela palavra `referência` encontrou o termo no campo `registroNotasReferencia`.
<img width="723" alt="image" src="https://github.com/user-attachments/assets/c62ccd10-7829-41c3-a10f-37ba9bdb9a7c">
Fonte: @crscnc 


#### 2.5 Buscar processo por texto (Figura 6). Os processos podem ser buscados por `autuacaoSei`, `estado` e `usuarioId`.

Figura 6: Buscar por processos em múltiplos campos. A busca pela palavra `despacho` encontrou o termo no campo `estado`.
<img width="722" alt="image" src="https://github.com/user-attachments/assets/19e01c30-dbc5-4897-9169-f7a82d104c53">
Fonte: @crscnc 


#### 2.6 Buscar por vistorias em múltiplos campos (Figura 7). As vistorias podem ser buscadas por `processoId`, `imovelId`, `descricao` e `usuarioId`

Figura 7: Buscar vistorias em múltiplos campos. A busca pela palavra `abandono` encontrou o termo no campo `descrição`.
<img width="721" alt="image" src="https://github.com/user-attachments/assets/55d24b08-54da-4cc9-b3bb-72d254742939">

Fonte: @crscnc 

______
### 3. Referências

1. https://www.prisma.io/docs/orm/prisma-client/queries/full-text-search
2. https://www.postgresql.org/docs/12/functions-textsearch.html
3. https://github.com/prisma/prisma/issues/23627
4. https://github.com/prisma/prisma/issues/8950
